### PR TITLE
Fixed some controls stop receiving mouse clicks when placed inside jconfirm modal.

### DIFF
--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -221,21 +221,27 @@ var jconfirm, Jconfirm;
         },
         _bindEvents: function () {
             var that = this;
+            var boxClicked = false;
             
             this.$el.find('.jconfirm-scrollpane').click(function (e) {
-                if (that.backgroundDismiss) {
-                    that.cancel();
-                    that.close();
-                } else {
-                    that.$b.addClass('hilight');
-                    setTimeout(function () {
-                        that.$b.removeClass('hilight');
-                    }, 400);
+                // ignore propagated clicks
+            	if (!boxClicked) {
+                    // background clicked
+                    if (that.backgroundDismiss) {
+                        that.cancel();
+                        that.close();
+                    } else {
+                        that.$b.addClass('hilight');
+                        setTimeout(function () {
+                            that.$b.removeClass('hilight');
+                        }, 400);
+                    }
                 }
+                boxClicked = false;
             });
             
             this.$el.find('.jconfirm-box').click(function (e) {
-                e.stopPropagation();
+                boxClicked = true;
             });
             
             if (this.$confirmButton) {


### PR DESCRIPTION
stopPropagtion() call was the cause of many strange behaviors of jquery controls in jquery-confirm modal layer.

P.S.
That change fixed the problem for me, so i havent tested it thoroughly with different jconfirm options.