### PR TITLE
Added Opacity as options

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,13 +372,14 @@
                                 <p class="text-success">Clean animations</p>
                             </div>
                         </div>
-                        <script type="text/javascript">
-                            $('.example-pc-3').on('click', function () {
+                        <script type="text/javascript">                           
+                            $(' .example-pc-3').on('click', function () {
                                 $.alert({
                                     title: 'Animations',
                                     content: 'jquery-confirm provides 12 animations to choose from.',
                                     animation: 'rotate',
                                     closeAnimation: 'right',
+                                    opacity: 0.5
                                 });
                             });
                             $('.example-pc-1').on('click', function () {
@@ -422,7 +423,7 @@
                                     confirmButton: 'Okay',
                                     confirmButtonClass: 'btn-primary',
                                     icon: 'fa fa-info',
-                                    animation: 'zoom',
+                                    animation: 'zoom',                                    
                                     confirm: function () {
                                         $.alert('Okay action clicked.');
                                     }
@@ -437,6 +438,7 @@
                                     icon: 'fa fa-question-circle',
                                     animation: 'scale',
                                     animationClose: 'top',
+                                    opacity: 0.5,
                                     confirm: function () {
                                         $.confirm({
                                             title: 'This maybe critical',
@@ -2196,6 +2198,7 @@ console.log(obj.content); // some content.
             };
             return t;
         }(document, "script", "twitter-wjs"));
+            //jconfirm.pluginDefaults.opacity = 0.5;
         </script>
         <!-- javascript for the demo page interface. -->
     </body>

--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -15,12 +15,14 @@ if (typeof jQuery === 'undefined') {
 var jconfirm, Jconfirm;
 (function ($) {
     "use strict";
-    $.fn.confirm = function (options, option2) {
+        
+    $.fn.confirm = function (options, option2) {        
         if (typeof options === 'undefined') options = {};
         if (typeof options === 'string')
             options = {
                 content: options,
                 title: (option2) ? option2 : false
+                
             };
         /*
          *  Alias of $.confirm to emulate native confirm()
@@ -140,7 +142,7 @@ var jconfirm, Jconfirm;
             this.$el = $(this.template).appendTo(this.container).addClass(this.theme);
             this.$el.find('.jconfirm-box-container').addClass(this.columnClass);
             this.$el.find('.jconfirm-bg').css(this._getCSS(this.animationSpeed, 1));
-
+            this.$el.find('.jconfirm-bg').css('background-color','rgba(0, 0, 0, '+this.opacity+')');
             this.$b = this.$el.find('.jconfirm-box').css(this._getCSS(this.animationSpeed, this.animationBounce)).addClass(this.animation);
             this.$body = this.$b; // alias
 
@@ -522,7 +524,7 @@ var jconfirm, Jconfirm;
             if (this.isClosed())
                 return false;
 
-            that.$el.find('.jconfirm-bg').addClass('seen');
+            that.$el.find('.jconfirm-bg').addClass('seen');           
             this.$b.removeClass(this.animation);
             this.$b.find('input[autofocus]:visible:first').focus();
             jconfirm.record.opened += 1;
@@ -556,7 +558,8 @@ var jconfirm, Jconfirm;
         content: 'Are you sure to continue?',
         contentLoaded: function () {
         },
-        icon: '',
+        icon: '',    
+        opacity: 0.2,
         confirmButton: 'Okay',
         cancelButton: 'Close',
         confirmButtonClass: 'btn-default',


### PR DESCRIPTION
https://github.com/craftpip/jquery-confirm/issues/70

As mentioned in the above issue, added opacity as option for the plugins. One can set opacity for individual alert like $.alert({..opacity: 0.5,..}); or in regular global way! If you like it, please merge this pull request!