### PR TITLE
Remove bootstrap dependency from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
         "tests"
     ],
     "dependencies": {
-        "bootstrap": "3.*",
         "jquery": ">=1.6"
     }
 }


### PR DESCRIPTION
In changelog of 3.0.1 there is "Removed bootstrap as dependency". Unfortunately this is not entirely true - you forgot to remove the dependency from bower.json.