### PR TITLE
Center alignment by default

### DIFF
--- a/css/jquery-confirm.css
+++ b/css/jquery-confirm.css
@@ -70,6 +70,7 @@ body[class*=jconfirm-no-scroll-] {
   position: relative;
   outline: none;
   padding: 15px 15px 0;
+  margin: 0 auto;
   overflow: hidden;
 }
 @-webkit-keyframes type-blue {
@@ -452,7 +453,6 @@ body[class*=jconfirm-no-scroll-] {
 }
 .jconfirm.jconfirm-white .jconfirm-box,
 .jconfirm.jconfirm-light .jconfirm-box {
-  margin: 0 auto;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
 }


### PR DESCRIPTION
At the moment the jquery-confirm has a very annoying bug: all pop-up windows (except those using light or white theme) are left aligned. [Demo of this bug](https://jsfiddle.net/HackedBeat/p0txftyg/10).

This patch fixes this problem. [Demo (css from my fork)](https://jsfiddle.net/HackedBeat/p0txftyg/11).