### PR TITLE
empty text property for button is no longer ignored

### DIFF
--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -620,7 +620,7 @@ var jconfirm, Jconfirm;
                     };
                 }
 
-                that.buttons[key].text = button.text || key;
+                that.buttons[key].text = button.text == undefined ? key : button.text;
                 that.buttons[key].btnClass = button.btnClass || 'btn-default';
                 that.buttons[key].action = button.action || function () {
                     };


### PR DESCRIPTION
If text property for a button is set to empty string, it is ignored.
See this for example: https://jsfiddle.net/3ec86t49/
Here BTN1 is displayed instead of empty text.
Empty text for button can be useful if someone wants an icon only (instead of some text)