### PR TITLE
fix safari bug where height is zero

### DIFF
--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -286,9 +286,9 @@ var jconfirm, Jconfirm;
                 // start countdown after content has loaded.
                 if (that.autoClose)
                     that._startCountDown();
+            }).then(function(){
+                that._watchContent();
             });
-
-            this._watchContent();
 
             if (this.animation === 'none') {
                 this.animationSpeed = 1;


### PR DESCRIPTION
fixes this issue https://github.com/craftpip/jquery-confirm/issues/78

[`_watchContent()`](https://github.com/craftpip/jquery-confirm/pull/336/files#diff-2a3a3e8b9fe993210c987377fb06ea0bL291) runs before promise resolves. Ensure html is loaded and [`_updateContentMaxHeight()`](https://github.com/craftpip/jquery-confirm/pull/336/files#diff-2a3a3e8b9fe993210c987377fb06ea0bR279) is called before watching content