### PR TITLE
Fix isClosed bug for Firefox

### DIFF
--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -1186,7 +1186,7 @@ var jconfirm, Jconfirm;
         },
         loadedClass: 'jconfirm-open',
         isClosed: function () {
-            return !this.$el || this.$el.css('display') === '';
+            return !this.$el || this.$el.parent().length === 0;
         },
         isOpen: function () {
             return !this.isClosed();


### PR DESCRIPTION
There's a bug with Firefox where after opening and closing a dialog
once, you can't open the dialog again.

I found the bug in the isClosed function.

isClosed() is checking if the elements display property has been set to
an empty string to determine if the element has been removed from the
page.

Chrome and Safari appear to work this way, but Firefox does not. After
removing the element, it's display property will still be "block",
not empty string. isClosed() will therefore return false, as if the
dialog was still open, and blocks the dialog from being opened again.

Since the setting of the display property isn't in the spec for the
ChildNode.remove() function, I changed the function to check if the
element has a parentNode or not. If there's no parentNode, then the
element has been removed from the DOM.