### PR TITLE
Update jquery-confirm.js to fix no-scroll class issue

### DIFF
--- a/js/jquery-confirm.js
+++ b/js/jquery-confirm.js
@@ -560,7 +560,7 @@
                         prevContentHeight = contentHeight;
                     }
                     var wh = $(window).height();
-                    var total = that.offsetTop + that.offsetBottom + that.$jconfirmBox.height() - that.$contentPane.height() + that.$content.height();
+                    var total = that.offsetTop + that.offsetBottom + that.$jconfirmBox.outerHeight() - that.$contentPane.outerHeight() + that.$content.outerHeight();
                     if(total < wh){
                         that.$contentPane.addClass('no-scroll');
                     }else{


### PR DESCRIPTION
Fixes #580

The no-scroll class is not given correctly due to the fact that the height is incorrectly calculated. We need to use the .outerHeight() function instead of the .height() function as we do in the _updateContentMaxHeight function.
https://a.supportally.com/i/urzsk5

With .height(): https://a.supportally.com/v/iwjyIm (I can't scroll even though the content is there)
With .outerHeight(): https://a.supportally.com/v/Ay4WIg